### PR TITLE
change planted time when tending grown plants

### DIFF
--- a/Accountant/Classes/PlantInfo.cs
+++ b/Accountant/Classes/PlantInfo.cs
@@ -50,6 +50,12 @@ public struct PlantInfo
             LastTending = tendTime.Value;
             if (PlantTime == DateTime.MinValue)
                 PlantTime = LastTending;
+            // if the plant is grown, and yet we tended it, assume it's a new plant
+            if (this.FinishTime() < tendTime)
+            {
+                PlantTime = LastTending;
+                AccuratePlantTime = false;
+            }
             ret = true;
         }
 


### PR DESCRIPTION
This change addresses the scenario where a grown plant is harvested and replanted by a tenant other than yourself, or replanted without the plugin being enabled.