### PR TITLE
Preserve growing countdown on groups with withered/grown plants

### DIFF
--- a/Accountant/Gui/Timer/Cache/TimerWindow.CropCache.ByOwner.cs
+++ b/Accountant/Gui/Timer/Cache/TimerWindow.CropCache.ByOwner.cs
@@ -99,11 +99,11 @@ public partial class TimerWindow
             if (tmp != oldColor)
             {
                 oldColor       = newColor;
-                oldDisplayTime = displayTime;
             }
-            else if (newColor == oldColor && oldDisplayTime > displayTime)
+            if (displayTime != DateTime.MinValue)
             {
-                oldDisplayTime = displayTime;
+                if (oldDisplayTime == DateTime.MinValue || oldDisplayTime > displayTime)
+                    oldDisplayTime = displayTime;
             }
         }
 


### PR DESCRIPTION
In a withered/grown group, still display the countdown if any plant is not withered/grown. This is useful if only some of your eight plants grew, but you still need to know how long until the rest die.

Specifically, this code:
1. Only updates the group timer if the incoming time is *not* min
2. Always prefers the incoming time if the group timer *is* min