### PR TITLE
AddonSelectString Fixes

### DIFF
--- a/Accountant/Manager/TimerManager.WheelManager.cs
+++ b/Accountant/Manager/TimerManager.WheelManager.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Logging;
 using Dalamud.Memory;
 using Dalamud.Plugin.Services;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using OtterLoc.Structs;
 
@@ -172,7 +173,7 @@ public partial class TimerManager
                 else
                 {
                     var fill     = button->Component->UldManager.NodeList[8]->ScaleX;
-                    var seString = MemoryHelper.ReadSeString(&((AtkTextNode*)button->Component->UldManager.NodeList[9])->NodeText);
+                    var seString = ((AtkTextNode*) button->Component->UldManager.NodeList[9])->NodeText.AsDalamudSeString();
                     seString.Payloads.RemoveAll(p => p is NewLinePayload);
                     var name = seString.TextValue;
                     var (item, _, grade) = Accountant.GameData.FindWheel(name);

--- a/AddonWatcher/Internal/AddonWatcherBaseDetours.cs
+++ b/AddonWatcher/Internal/AddonWatcherBaseDetours.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using AddonWatcher.Enums;
 using AddonWatcher.Structs;
 using FFXIVClientStructs.FFXIV.Client.UI;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace AddonWatcher.Internal;
 
@@ -82,11 +81,11 @@ internal partial class AddonWatcherBase
             var owner = ((PopupMenu*)atkUnit)->Owner;
             if (SelectStringName.EqualsNullTerminated(owner->Name))
             {
-                var ptr             = (IntPtr)owner;
-                var idx             = ((byte*)data)[0x10];
-                var renderer        = *(AtkComponentListItemRenderer**)data;
-                var descriptionText = ((SelectStringInfo)ptr).Description;
-                var itemText        = Helpers.TextNodeToString(renderer->AtkComponentButton.ButtonTextNode);
+                var ptr              = (IntPtr)owner;
+                var idx              = ((byte*)data)[0x10];
+                var selectStringInfo = (SelectStringInfo) ptr;
+                var descriptionText  = selectStringInfo.Description;
+                var itemText         = selectStringInfo.ItemText(idx);
                 _log.Verbose("String {ButtonText} ({Which}) selected on 0x{SelectStringPtr:X} with description {Description}.", itemText,
                     which, (ulong)ptr, descriptionText);
                 StringSelected!.Invoke(ptr, idx, itemText, descriptionText);

--- a/AddonWatcher/Internal/Helpers.cs
+++ b/AddonWatcher/Internal/Helpers.cs
@@ -1,5 +1,5 @@
 ﻿using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Memory;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace AddonWatcher.Internal;
@@ -8,6 +8,6 @@ public static class Helpers
 {
     public static unsafe SeString TextNodeToString(AtkTextNode* node)
         => node->AtkResNode.Type == NodeType.Text 
-            ? MemoryHelper.ReadSeString(&node->NodeText) 
+            ? node->NodeText.AsDalamudSeString()
             : SeString.Empty;
 }

--- a/AddonWatcher/Structs/SelectStringInfo.cs
+++ b/AddonWatcher/Structs/SelectStringInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AddonWatcher.Internal;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -22,7 +23,7 @@ public unsafe struct SelectStringInfo
         => List->ListLength;
 
     public SeString ItemText(int idx)
-        => Helpers.TextNodeToString(List->ItemRendererList[idx].AtkComponentListItemRenderer->AtkComponentButton.ButtonTextNode);
+        => Pointer->AtkValuesSpan[7 + idx].String.AsDalamudSeString();
 
     public SeString Description
     {


### PR DESCRIPTION
~~(Currently Untested, waiting response from testers)~~ 

~~This *should* be fine to merge without testing, but that's entirely up to you.~~
Update: Testing complete, ready to go.

Replaces the string parsing from the list item renderer, to use the addons AtkValues directly.
This allows me to edit the string in the UI with effecting Accountants parsing of data.

Also fixed a couple build warnings.